### PR TITLE
Initialize fix

### DIFF
--- a/EmotionDynamics.cc
+++ b/EmotionDynamics.cc
@@ -63,7 +63,7 @@ EmotionDynamics::init()
 
     xPos = 0;
     yPos = 0;
-    zPos = 0;
+    zPos = 100;
 }
 
 /*!


### PR DESCRIPTION
Morti wrote:
Ich habe heute eine Bug bei WASABI entdeckt und gefixt. Wenn ein Agent erstellt wird und direkt darauf ein Impuls erfolgt, bevor ein Update Schritt ausgeführt wird, hat die PAD Position einen zufälligen Wert. Im Konstruktor wurde die Position nicht gesetzt, und so hat die PAD Position einen zufälligen Wert. Ich habe das auf P=0, A=0, D=100 initialisiert. Der Fix ist im Branch initializeFix gepushed.
