### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/WASABIRunner.cc
+++ b/src/WASABIRunner.cc
@@ -58,7 +58,7 @@ int main(int argc, char* argv[])
                     filelogging = true;
                     cout << "filelogging enabled" << endl;
                 }
-                unsigned int pos = option.find("-with-agent:", 0);
+                size_t pos = option.find("-with-agent:", 0);
                 if (pos != std::string::npos) { //(option == "Emma" || option == "EMMA") {
                     Character_Name = option.substr(12);
                     std::cout << "Character_Name set to \"" << Character_Name << "\"" << std::endl;
@@ -66,7 +66,7 @@ int main(int argc, char* argv[])
                 else {
                     cout << "Option: -with-agent not found" << endl;
                 }
-                unsigned int pos2 = option.find("-with-emotions:", 0);
+                size_t pos2 = option.find("-with-emotions:", 0);
                 if (pos2 != std::string::npos) {
                     cout << "FOUND -with-emotions option!" << endl;
                     Class = option.substr(15);

--- a/src/cogaAttendee.cc
+++ b/src/cogaAttendee.cc
@@ -31,7 +31,7 @@ cogaAttendee::cogaAttendee()
 {
     //globalCount++;
     //std::cout << "cogaAttendee: globalCount = " << globalCount << std::endl;
-    localID = localID++;
+    localID++;
     globalID = "undef";
     _name = "John Doe";
     owner = "undef";


### PR DESCRIPTION
**warning: multiple unsequenced modifications to 'localID'**:

This warning is caused by the statement `localID = localID++`, which is resulting in undefined behavior. Compiled with `clang++`, the following example illustrates the issue:

``` c++
int a = 0;
std::cout << a << std::endl;
a = a++;
std::cout << a << std::endl;
```

Generated output:

```
0
0
```

**warning: comparison of constant 1844... with expression of type 'unsigned int' is always true**:

`std::string::find()` returns a value of type `size_t`. The range of this type is defined by the underlying platform (32 or 64 bit). Since the size of `unsigned int` is only 4, but `sizeof(size_t)` is 8, an expression comparing these two types for equality cannot be true ([better explanation](http://www.dreamincode.net/forums/topic/281841-size-t-and-unsigned-int-on-mac-os-105/page__view__findpost__p__1638544?s=9aa8e70fde8994aa4fa6a1be7b856d35)).

Simply changing the type of `pos` and `pos2` to `size_t` resolves the issue.
